### PR TITLE
Smaller cache size for poverty, copy tensor for fmow

### DIFF
--- a/wilds/datasets/fmow_dataset.py
+++ b/wilds/datasets/fmow_dataset.py
@@ -178,7 +178,7 @@ class FMoWDataset(WILDSDataset):
        batch_idx = idx // self.chunk_size
        within_batch_idx = idx % self.chunk_size
        img_batch = np.load(self.root / f'rgb_all_imgs_{batch_idx}.npy', mmap_mode='r')
-       return img_batch[within_batch_idx]
+       return img_batch[within_batch_idx].copy()
 
     def eval(self, y_pred, y_true, metadata):
         # Overall evaluation + evaluate by year

--- a/wilds/datasets/poverty_dataset.py
+++ b/wilds/datasets/poverty_dataset.py
@@ -146,10 +146,11 @@ class PovertyMapDataset(WILDSDataset):
     _version = '1.0'
 
     def __init__(self, root_dir='data', download=False, split_scheme='official',
-                 no_nl=True, fold='A', oracle_training_set=False, use_ood_val=False):
+                 no_nl=True, fold='A', oracle_training_set=False, use_ood_val=False, cache_size=100):
 
         self._compressed_size = 18_630_656_000
         self._data_dir = self.initialize_data_dir(root_dir, download)
+        self.cache_size = cache_size
 
         self._split_dict = {'train': 0, 'id_val': 1, 'id_test': 2, 'val': 3, 'test': 4}
         self._split_names = {'train': 'Train', 'id_val': 'ID Val', 'id_test': 'ID Test', 'val': 'OOD Val', 'test': 'OOD Test'}
@@ -242,7 +243,7 @@ class PovertyMapDataset(WILDSDataset):
        img = torch.from_numpy(img).float()
 
        self.cache_counter += 1
-       if self.cache_counter > 100:
+       if self.cache_counter > self.cache_size:
            self.imgs = np.load(self.root / 'landsat_poverty_imgs.npy', mmap_mode='r')
            self.imgs = self.imgs.transpose((0, 3, 1, 2))
            self.cache_counter = 0

--- a/wilds/datasets/poverty_dataset.py
+++ b/wilds/datasets/poverty_dataset.py
@@ -242,7 +242,7 @@ class PovertyMapDataset(WILDSDataset):
        img = torch.from_numpy(img).float()
 
        self.cache_counter += 1
-       if self.cache_counter > 1000:
+       if self.cache_counter > 100:
            self.imgs = np.load(self.root / 'landsat_poverty_imgs.npy', mmap_mode='r')
            self.imgs = self.imgs.transpose((0, 3, 1, 2))
            self.cache_counter = 0

--- a/wilds/datasets/poverty_dataset.py
+++ b/wilds/datasets/poverty_dataset.py
@@ -234,21 +234,23 @@ class PovertyMapDataset(WILDSDataset):
         super().__init__(root_dir, download, split_scheme)
 
     def get_input(self, idx):
-       """
-       Returns x for a given idx.
-       """
-       img = self.imgs[idx].copy()
-       if self.no_nl:
-           img[-1] = 0
-       img = torch.from_numpy(img).float()
+        """
+        Returns x for a given idx.
+        """
+        img = self.imgs[idx].copy()
+        if self.no_nl:
+            img[-1] = 0
+        img = torch.from_numpy(img).float()
 
-       self.cache_counter += 1
-       if self.cache_counter > self.cache_size:
-           self.imgs = np.load(self.root / 'landsat_poverty_imgs.npy', mmap_mode='r')
-           self.imgs = self.imgs.transpose((0, 3, 1, 2))
-           self.cache_counter = 0
+        # consider refreshing cache if cache_size is limited
+        if self.cache_size < self.imgs.shape[0]:
+            self.cache_counter += 1
+            if self.cache_counter > self.cache_size:
+                self.imgs = np.load(self.root / 'landsat_poverty_imgs.npy', mmap_mode='r')
+                self.imgs = self.imgs.transpose((0, 3, 1, 2))
+                self.cache_counter = 0
 
-       return img
+        return img
 
     def eval(self, y_pred, y_true, metadata):
         all_results = {}


### PR DESCRIPTION
- Copies the tensors in the batch for fmow to allow them to be changed downstream instead of being read-only
- Smaller default cache size for poverty dataset 