### PR TITLE
Add requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ cd wilds
 pip install -e .
 ```
 
+Requirements can be install from requirements.txt file:
+```bash
+pip install -r requirements.txt
+```
+
 ### Requirements
 - numpy>=1.19.1
 - pandas>=1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+numpy==1.19.1
+pandas==1.1.0
+pillow==7.2.0
+torch==1.7.0
+tqdm==4.53.0
+pytz==2020.4
+outdated==0.2.0
+ogb==1.2.3


### PR DESCRIPTION
- Added a requirements.txt file so that contributors and users can install the required dependencies by pressing a single command.
- Added to the documentation, the required command to install the dependencies.
- ```torch-scatter``` and ```torch-geometric``` are not included in the requirements.txt file since I didn't figure out a way to prevent them from being installed automatically. As a result, they still need to be installed manually, as stated in the documentation.