### PR TITLE
Make package less dependent on pytorch_scatter

### DIFF
--- a/wilds/common/utils.py
+++ b/wilds/common/utils.py
@@ -1,4 +1,4 @@
-import torch, torch_scatter
+import torch
 import numpy as np
 from torch.utils.data import Subset
 from pandas.api.types import CategoricalDtype
@@ -81,6 +81,7 @@ def avg_over_groups(v, g, n_groups):
         group_avgs (Tensor): Vector of length num_groups
         group_counts (Tensor)
     """
+    import torch_scatter
     assert v.device==g.device
     device = v.device
     assert v.numel()==g.numel()


### PR DESCRIPTION
Thanks for this great package and dataset curation!

It seems to me that we can reduce the dependency on `torch_scatter` for users like me who don't need the metrics part of the package. This PR moves the global import into the only function that requires `torch_scatter`. This allows the user to freely use the other nicely predefined functions without having to install pytorch_scatter, which can be a hassle.

Any thoughts?