### PR TITLE
Updated wilds_dataset.py

### DIFF
--- a/wilds/datasets/wilds_dataset.py
+++ b/wilds/datasets/wilds_dataset.py
@@ -512,7 +512,7 @@ class WILDSSubset(WILDSDataset):
 
     @property
     def y_array(self):
-        return self.dataset._y_array[self.indices]
+        return self.dataset.y_array[self.indices]
 
     @property
     def metadata_array(self):


### PR DESCRIPTION
Changed ```_y_array``` to ```y_array``` in WILDSSubset class.
This change will resolve the error that arise when you take a wildssubset out of a wildsdataset and try to get its targets.
```AttributeError: 'WILDSSubset' object has no attribute '_y_array'```
